### PR TITLE
When renaming grid definition, show server error message

### DIFF
--- a/bencloud-quasar/src/components/datacenter/grids/GridDefinitions.vue
+++ b/bencloud-quasar/src/components/datacenter/grids/GridDefinitions.vue
@@ -111,18 +111,21 @@ export default defineComponent({
         // Make the API call to update the grid name after confirmation
         const response = await axios.put(
           `${process.env.API_SERVER}/api/grid-definitions/${props.row.id}`,
-          templateData
+          templateData,
+          {validateStatus: function (status) {
+            return true;
+          }}
         );
 
         if (response && response.status === 200) {
           this.$q.notify({ type: "positive", message: "Grid name updated successfully!" });
           props.row.name = newName;
         } else {
-          throw new Error(response?.message || "Failed to update grid name.");
+          throw new Error(response?.data?.message || "Update failed, please try again.");
         }
       } catch (apiError) {
         console.error("API Error:", apiError.message);
-        this.$q.notify({ type: "negative", message: "Update failed, please try again." });
+        this.$q.notify({ type: "negative", message: apiError.message });
       }
     });
 


### PR DESCRIPTION
When editing a grid definition and the update failed because the name is already used, the error message from the server explaining was not showing up, just a default message.

The "response" variable was undefined when getting the 409 status from the server, so "validateStatus" fixes that.
See here for more details: https://github.com/axios/axios/issues/472