### PR TITLE
Fix bug for POST batch task export

### DIFF
--- a/bencloud-quasar/src/components/datacenter/tasks/DownloadTaskResultsDialog.vue
+++ b/bencloud-quasar/src/components/datacenter/tasks/DownloadTaskResultsDialog.vue
@@ -388,7 +388,7 @@ export default {
       };
 
       axios
-        .post(downloadUrl, payload)
+        .post(downloadUrl, payload, {headers: { "Content-Type": "application/x-www-form-urlencoded" }})
         .then((response) => {
           self.$q.notify({
             type: "positive",


### PR DESCRIPTION
The server was expecting to be able to get the data with getParameter(), but the request was putting the data in the body as JSON. Changing the content type in the header puts the data in the format that the server is expecting.