### PR TITLE
Add missing Promise.reject(error) to interceptors

### DIFF
--- a/bencloud-quasar/src/components/datacenter/grids/GridDefinitions.vue
+++ b/bencloud-quasar/src/components/datacenter/grids/GridDefinitions.vue
@@ -112,21 +112,18 @@ export default defineComponent({
         // Make the API call to update the grid name after confirmation
         const response = await axios.put(
           `${process.env.API_SERVER}/api/grid-definitions/${props.row.id}`,
-          templateData,
-          {validateStatus: function (status) {
-            return true;
-          }}
+          templateData
         );
 
-        if (response && response.status === 200) {
+        if (response.status === 200) {
           this.$q.notify({ type: "positive", message: "Grid name updated successfully!" });
           props.row.name = newName;
         } else {
-          throw new Error(response?.data?.message || "Update failed, please try again.");
+          throw new Error("Update failed, please try again.");
         }
       } catch (apiError) {
         console.error("API Error:", apiError.message);
-        this.$q.notify({ type: "negative", message: apiError.message });
+        this.$q.notify({ type: "negative", message: apiError?.response?.data?.message || apiError.message });
       }
     });
 

--- a/bencloud-quasar/src/layouts/MainLayout.vue
+++ b/bencloud-quasar/src/layouts/MainLayout.vue
@@ -118,6 +118,7 @@ export default defineComponent({
             // For non-302 errors with no message, display a generic error pop up 
           }
         }     
+        return Promise.reject(error);
       }
     )
 


### PR DESCRIPTION
The axios interceptors did not have a Promise.reject(error) as expected. See: https://axios-http.com/docs/interceptors

This was causing "catch" to never be triggered. Instead, "then" would be called, but the response would be undefined if the status was out of valid range.

To work around this, we used "validateStatus" to avoid the response being undefined. Be default, 200-299 range status is considered a success and all others are sent to "catch". With "validateStatus" that range can be changed.

I removed the workaround I had created in GridDefinition.vue.