### PR TITLE
BWD-72 & BWD-61

### DIFF
--- a/bencloud-quasar/src/components/analysis/AirQualityPostPolicyMetricSelection.vue
+++ b/bencloud-quasar/src/components/analysis/AirQualityPostPolicyMetricSelection.vue
@@ -67,10 +67,13 @@ export default defineComponent({
             " | " +
             prevSelectedItem
         );
-        if(selectedScenario.value != null && !store.state.analysis.postPolicyAirQualityName.includes(selectedScenario.value)) {
+        if(selectedScenario.value != null && !store.state.analysis.postPolicyAirQualityName.some(element => element.name === selectedScenario.value)) {
           selectedScenario.value = null;
         }
         loadPostPolicyScenarios(true);
+        if (selectedScenario.value === null && scenarios.value.length >= 1) {
+          selectedScenario.value = scenarios.value[0];
+        }
       }
     );
 

--- a/bencloud-quasar/src/components/exposure/AirQualityPostPolicyMetricSelection.vue
+++ b/bencloud-quasar/src/components/exposure/AirQualityPostPolicyMetricSelection.vue
@@ -67,10 +67,13 @@ export default defineComponent({
             " | " +
             prevSelectedItem
         );
-        if(selectedScenario.value != null && !store.state.exposure.postPolicyAirQualityName.includes(selectedScenario.value)) {
+        if(selectedScenario.value != null && !store.state.exposure.postPolicyAirQualityName.some(element => element.name === selectedScenario.value)) {
           selectedScenario.value = null;
         }
         loadPostPolicyScenarios(true);
+        if (selectedScenario.value === null && scenarios.value.length >= 1) {
+          selectedScenario.value = scenarios.value[0];
+        }
       }
     );
 

--- a/bencloud-quasar/src/components/navigation/AppNavLinks.vue
+++ b/bencloud-quasar/src/components/navigation/AppNavLinks.vue
@@ -3,6 +3,7 @@
     clickable
     tag="a"
     :href="link"
+    :target="openInNewTab ? '_blank' : '_self'"
     manual-focus
   >
     <q-item-section
@@ -46,6 +47,11 @@ export default defineComponent({
     icon: {
       type: String,
       default: ''
+    },
+
+    openInNewTab: {
+      type: Boolean,
+      default: false
     }
   }
 })

--- a/bencloud-quasar/src/layouts/MainLayout.vue
+++ b/bencloud-quasar/src/layouts/MainLayout.vue
@@ -46,12 +46,14 @@ const linksList = [
     caption: "",
     icon: "mdi-home",
     link: "/#/",
+    openInNewTab: false
   },
   {
     title: "Data Center",
     caption: "",
     icon: "mdi-chart-box-outline",
     link: "/#/datacenter",
+    openInNewTab: false
   },
   // {
   //   title: "Settings",
@@ -70,12 +72,14 @@ const linksList = [
     caption: "",
     icon: "mdi-help",
     link: "https://www.epa.gov/benmap/benmap-cloud",
+    openInNewTab: true
   },
   {
     title: "Feedback",
     caption: "",
     icon: "mdi-comment-text-outline",
     link: "https://www.epa.gov/benmap/forms/contact-us-about-benmap",
+    openInNewTab: true
   },
 ];
 


### PR DESCRIPTION
BWD-72 clicking Help and Feedback should open page in a new tab
BWD-61 On What Air Quality page, when the first post-policy scenario is chosen, automatically select that entry in the drop down list below

Also fixed a bug where the selected scenario was always de-selected when a scenario was checked or unchecked above.